### PR TITLE
Fix LQNS analysis when providing the instance with the PcmBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This file keeps track of all changes to this project. This project follows [sema
 
 ## [UNRELEASED]
 
+### Fixes
+- Fixed issues when running the LQNS analysis with a model built by the `PcmBuilder`.
+
 ### Added
 - Major refactoring to split prototype to several classes.
 - Builder API to construct PCM instances using an API (see [PR #3](https://github.com/SQuAT-Team/palladio-lqns-headless/pull/3))

--- a/src/main/java/de/fabiankeller/palladio/RunLqnsWithBuilder.java
+++ b/src/main/java/de/fabiankeller/palladio/RunLqnsWithBuilder.java
@@ -5,6 +5,7 @@ import de.fabiankeller.palladio.analysis.runner.pcm2lqn.Pcm2LqnAnalysisConfig;
 import de.fabiankeller.palladio.analysis.runner.pcm2lqn.Pcm2LqnRunner;
 import de.fabiankeller.palladio.builder.PcmBuilder;
 import de.fabiankeller.palladio.config.EnvironmentConfig;
+import de.fabiankeller.palladio.config.PcmModelConfig;
 import de.fabiankeller.palladio.environment.PalladioEclipseEnvironment;
 import org.palladiosimulator.solver.models.PCMInstance;
 
@@ -32,12 +33,17 @@ public class RunLqnsWithBuilder extends RunLQNS {
     @Override
     public void run() {
         log.info("Launching LQNS headless");
+        this.runnerConfig.setProperty(PcmModelConfig.PROPERTY_USAGE_MODEL, "default.usagemodel");
+        this.runnerConfig.setProperty(PcmModelConfig.PROPERTY_ALLOCATION_MODEL, "default.allocation");
         PalladioEclipseEnvironment.INSTANCE.setup(new EnvironmentConfig(this.runnerConfig));
 
         final PCMInstance instance = new SimpleTacticsProvider().provide();
-        instance.saveToFiles("palladio-headless");
 
         final Pcm2LqnRunner runner = new Pcm2LqnRunner(new Pcm2LqnAnalysisConfig(this.runnerConfig));
         runner.analyze(instance);
+
+        // WARNING: saving the files actually removes them from the PCMResourceSetPartition! therefore the model can
+        // only be saved AFTER the analysis has been performed!
+        instance.saveToFiles("palladio-headless");
     }
 }

--- a/src/main/java/de/fabiankeller/palladio/config/PcmModelConfig.java
+++ b/src/main/java/de/fabiankeller/palladio/config/PcmModelConfig.java
@@ -6,14 +6,14 @@ import java.util.Properties;
  * Config parameters to locate certain PCM models.
  */
 public class PcmModelConfig extends AbstractPropertiesConfig {
-    private static final String PROPERTY_USAGE_MODEL = "Filename_UsageModel";
-    private static final String PROPERTY_ALLOCATION_MODEL = "Filename_AllocationModel";
+    public static final String PROPERTY_USAGE_MODEL = "Filename_UsageModel";
+    public static final String PROPERTY_ALLOCATION_MODEL = "Filename_AllocationModel";
 
     public PcmModelConfig() {
         super();
     }
 
-    public PcmModelConfig(Properties config) {
+    public PcmModelConfig(final Properties config) {
         super(config);
     }
 
@@ -21,7 +21,7 @@ public class PcmModelConfig extends AbstractPropertiesConfig {
         return this.getPropertyNotNull(PROPERTY_USAGE_MODEL);
     }
 
-    public void setUsageModel(String usageModel) {
+    public void setUsageModel(final String usageModel) {
         this.setProperty(PROPERTY_USAGE_MODEL, usageModel);
     }
 
@@ -29,7 +29,7 @@ public class PcmModelConfig extends AbstractPropertiesConfig {
         return this.getPropertyNotNull(PROPERTY_ALLOCATION_MODEL);
     }
 
-    public void setAllocationModel(String allocationModel) {
+    public void setAllocationModel(final String allocationModel) {
         this.setProperty(PROPERTY_ALLOCATION_MODEL, allocationModel);
     }
 }


### PR DESCRIPTION
The analysis will not run through yet, as there are still some parts of the PCM model not covered by the builder API.